### PR TITLE
Prevent adding non WebVTT tracks to player

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -426,7 +426,8 @@ function createStreamInfo(item, mediaSource, startPosition) {
     var subtitleStreams = mediaSource.MediaStreams.filter(function (stream) { return stream.Type === "Subtitle"; });
     var subtitleTracks = []
     subtitleStreams.forEach(function(subtitleStream) {
-        if(subtitleStream.Codec !== 'vtt' && subtitleStream.Codec !== 'webvtt') {
+        let subStreamCodec = subtitleStream.Codec.toLowerCase();
+        if (subStreamCodec !== 'vtt' && subStreamCodec !== 'webvtt') {
             /* the CAF v3 player only supports vtt currently,
             support for more could be added with a custom implementation*/
             return;

--- a/helpers.js
+++ b/helpers.js
@@ -426,6 +426,11 @@ function createStreamInfo(item, mediaSource, startPosition) {
     var subtitleStreams = mediaSource.MediaStreams.filter(function (stream) { return stream.Type === "Subtitle"; });
     var subtitleTracks = []
     subtitleStreams.forEach(function(subtitleStream) {
+        if(subtitleStream.Codec !== 'vtt' && subtitleStream.Codec !== 'webvtt') {
+            /* the CAF v3 player only supports vtt currently,
+            support for more could be added with a custom implementation*/
+            return;
+        }
         var textStreamUrl = subtitleStream.IsExternalUrl ? subtitleStream.DeliveryUrl : (getUrl(item.serverAddress, subtitleStream.DeliveryUrl));
 
         var track = new cast.framework.messages.Track(info.subtitleStreamIndex, cast.framework.messages.TrackType.TEXT)


### PR DESCRIPTION
Currently it tries to add all subtitles returned by the server as tracks, even unsupported ones. This will now prevent any subs except WebVTT to be added, since there's no native support for other formats. 

This will allow burned in subs to work without an error interrupting the playback.

**Fixes**
https://github.com/jellyfin/jellyfin-chromecast/pull/7#issuecomment-488108727