### PR TITLE
Fix playback-logo-image and error when backdropurl is null

### DIFF
--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -878,11 +878,13 @@
         } else if (item.ParentBackdropItemId && item.ParentBackdropImageTags && item.ParentBackdropImageTags.length) {
             backdropUrl = $scope.serverAddress + '/emby/Items/' + item.ParentBackdropItemId + '/Images/Backdrop/0?tag=' + item.ParentBackdropImageTags[0];
         }
-        var logoUrl = getLogoUrl(item, item.serverAddress);
-        let playerElement = document.getElementsByTagName("cast-media-player")[0];
-        playerElement.style.setProperty('--background-image', 'url("' + backdropUrl + '")');
-        // TODO why you no work???
-        document.body.style.setProperty('--playback-logo-image', 'url("' + logoUrl + '")');
+        
+        if (backdropUrl) {
+            window.mediaElement.style.setProperty('--background-image', 'url("' + backdropUrl + '")');
+        } else {
+            //Replace with a placeholder?
+            window.mediaElement.style.removeProperty('--background-image');
+        }
 
         jellyfinActions.reportPlaybackStart($scope, getReportingParams($scope));
 


### PR DESCRIPTION
Changes:
Applies the jellyfin logo straight from the CSS (I think this is better than using the songs/albums "logo")

Checks if backdropurl is null before setting `--background-image`

Fixes:
![image](https://user-images.githubusercontent.com/6439218/75289512-c1afab80-581e-11ea-9bdb-40d1d9ac1bfd.png)

(Logo in the left corner)
![jZObnjdtjkgVztJVucZGDziv](https://user-images.githubusercontent.com/6439218/75289741-3c78c680-581f-11ea-9297-ef5373083be6.png)
